### PR TITLE
fix: don't ignore Maven Wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,3 @@ out/
 
 # VS Code
 .vscode/
-
-# Maven wrapper
-.mvn/
-mvnw


### PR DESCRIPTION
Maven Wrapper is part of generated Hilla applications and should be shared with other developers.