### PR TITLE
fix: avoid returning assignment

### DIFF
--- a/src/main/frontend/views/@layout.tsx
+++ b/src/main/frontend/views/@layout.tsx
@@ -17,7 +17,7 @@ const vaadin = window.Vaadin as {
   documentTitleSignal: Signal<string>;
 };
 vaadin.documentTitleSignal = signal("");
-effect(() =>  document.title = vaadin.documentTitleSignal.value);
+effect(() => { document.title = vaadin.documentTitleSignal.value });
 
 export default function MainLayout() {
   const currentTitle = useViewConfig()?.title ?? '';

--- a/src/main/frontend/views/@layout.tsx
+++ b/src/main/frontend/views/@layout.tsx
@@ -17,7 +17,9 @@ const vaadin = window.Vaadin as {
   documentTitleSignal: Signal<string>;
 };
 vaadin.documentTitleSignal = signal("");
-effect(() => { document.title = vaadin.documentTitleSignal.value });
+effect(() => {
+  document.title = vaadin.documentTitleSignal.value;
+});
 
 export default function MainLayout() {
   const currentTitle = useViewConfig()?.title ?? '';


### PR DESCRIPTION
An assignment is returned and causes type error. Addin curly braces to avoid that.