### PR TITLE
chore: Include spotless formatter (#1234)

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+    "singleQuote": true,
+    "printWidth": 120,
+    "bracketSameLine": true
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <!-- Hilla project from https://github.com/vaadin/skeleton-starter-hilla-react -->
     <groupId>com.example.application</groupId>
@@ -97,6 +98,31 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>2.43.0</version>
+                <configuration>
+                    <java>
+                        <palantirJavaFormat>
+                            <version>2.50.0</version>
+                        </palantirJavaFormat>
+                    </java>
+                    <typescript>
+                        <includes>
+                            <include>src/main/frontend/**/*.ts</include>
+                            <include>src/main/frontend/**/*.tsx</include>
+                        </includes>
+                        <excludes>
+                            <exclude>src/main/frontend/generated/**</exclude>
+                        </excludes>
+                        <prettier>
+                            <prettierVersion>3.3.3</prettierVersion>
+                            <configFile>.prettierrc.json</configFile>
+                        </prettier>
+                    </typescript>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/src/main/frontend/views/@index.tsx
+++ b/src/main/frontend/views/@index.tsx
@@ -1,16 +1,16 @@
-import { Button, Notification, TextField } from "@vaadin/react-components";
-import { HelloEndpoint } from "Frontend/generated/endpoints.js";
-import { useState } from "react";
-import type { ViewConfig } from "@vaadin/hilla-file-router/types.js";
+import { Button, Notification, TextField } from '@vaadin/react-components';
+import { HelloEndpoint } from 'Frontend/generated/endpoints.js';
+import { useState } from 'react';
+import type { ViewConfig } from '@vaadin/hilla-file-router/types.js';
 
 export const config: ViewConfig = {
-    menu: {
-        title: "Main page"
-    }
+  menu: {
+    title: 'Main page',
+  },
 };
 
 export default function MainView() {
-  const [name, setName] = useState("");
+  const [name, setName] = useState('');
 
   return (
     <>
@@ -24,8 +24,7 @@ export default function MainView() {
         onClick={async () => {
           const serverResponse = await HelloEndpoint.sayHello(name);
           Notification.show(serverResponse);
-        }}
-      >
+        }}>
         Say hello
       </Button>
     </>

--- a/src/main/frontend/views/@layout.tsx
+++ b/src/main/frontend/views/@layout.tsx
@@ -1,22 +1,13 @@
-import {
-  AppLayout,
-  DrawerToggle,
-  ProgressBar,
-  SideNav,
-  SideNavItem,
-} from "@vaadin/react-components";
-import {
-  createMenuItems,
-  useViewConfig,
-} from "@vaadin/hilla-file-router/runtime.js";
-import {Suspense, useEffect} from "react";
-import { Outlet, useLocation, useNavigate } from "react-router-dom";
+import { AppLayout, DrawerToggle, ProgressBar, SideNav, SideNavItem } from '@vaadin/react-components';
+import { createMenuItems, useViewConfig } from '@vaadin/hilla-file-router/runtime.js';
+import { Suspense, useEffect } from 'react';
+import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { Signal, signal, effect } from '@vaadin/hilla-react-signals';
 
 const vaadin = window.Vaadin as {
   documentTitleSignal: Signal<string>;
 };
-vaadin.documentTitleSignal = signal("");
+vaadin.documentTitleSignal = signal('');
 effect(() => {
   document.title = vaadin.documentTitleSignal.value;
 });
@@ -28,36 +19,33 @@ export default function MainLayout() {
 
   useEffect(() => {
     vaadin.documentTitleSignal.value = currentTitle;
-  })
+  });
 
   return (
-      <AppLayout primarySection="drawer">
-        <div slot="drawer" className="flex flex-col justify-between h-full p-m">
-          <header className="flex flex-col gap-m">
-            <h1 className="text-l m-0">{vaadin.documentTitleSignal}</h1>
-            <SideNav
-                onNavigate={({path}) => navigate(path!)}
-                location={location}
-            >
-              {createMenuItems().map(({to, title}) => (
-                  <SideNavItem path={to} key={to}>
-                    {title}
-                  </SideNavItem>
-              ))}
-            </SideNav>
-          </header>
-        </div>
+    <AppLayout primarySection="drawer">
+      <div slot="drawer" className="flex flex-col justify-between h-full p-m">
+        <header className="flex flex-col gap-m">
+          <h1 className="text-l m-0">{vaadin.documentTitleSignal}</h1>
+          <SideNav onNavigate={({ path }) => navigate(path!)} location={location}>
+            {createMenuItems().map(({ to, title }) => (
+              <SideNavItem path={to} key={to}>
+                {title}
+              </SideNavItem>
+            ))}
+          </SideNav>
+        </header>
+      </div>
 
-        <DrawerToggle slot="navbar" aria-label="Menu toggle"></DrawerToggle>
-        <h2 slot="navbar" className="text-l m-0">
-          {vaadin.documentTitleSignal}
-        </h2>
+      <DrawerToggle slot="navbar" aria-label="Menu toggle"></DrawerToggle>
+      <h2 slot="navbar" className="text-l m-0">
+        {vaadin.documentTitleSignal}
+      </h2>
 
-        <Suspense fallback={<ProgressBar indeterminate className="m-0"/>}>
-          <section className="view">
-            <Outlet/>
-          </section>
-        </Suspense>
-      </AppLayout>
+      <Suspense fallback={<ProgressBar indeterminate className="m-0" />}>
+        <section className="view">
+          <Outlet />
+        </section>
+      </Suspense>
+    </AppLayout>
   );
 }

--- a/src/main/java/org/vaadin/example/Application.java
+++ b/src/main/java/org/vaadin/example/Application.java
@@ -19,5 +19,4 @@ public class Application implements AppShellConfigurator {
     public static void main(String[] args) {
         SpringApplication.run(Application.class, args);
     }
-
 }


### PR DESCRIPTION
Uses https://github.com/palantir/palantir-java-format for Java which seems to be pretty close to the 'Vaadin conventions' by default Uses prettier for TypeScript and React code
